### PR TITLE
Add multi-line support

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,13 +127,14 @@ function animateString(str, effect, delay, speed) {
 
 	currentAnimation = {
 		text: str,
+		lines: str.split(/\r\n|\r|\n/).length,
 		stopped: false,
 		init: false,
 		f: 0,
 		render() {
 			const self = this;
 			if (!this.init) {
-				log('');
+				log('\n'.repeat(this.lines - 1));
 				this.init = true;
 			}
 			log(this.frame());
@@ -144,7 +145,7 @@ function animateString(str, effect, delay, speed) {
 			}, delay / speed);
 		},
 		frame() {
-			return '\u001B[1F\u001B[G\u001B[2K' + effect(this.text, this.f++);
+			return '\u001B[' + this.lines + 'F\u001B[G\u001B[2K' + effect(this.text, this.f++);
 		},
 		replace(str) {
 			this.text = str;

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function animateString(str, effect, delay, speed) {
 	}
 
 	currentAnimation = {
-		text: str,
+		text: str.split(/\r\n|\r|\n/),
 		lines: str.split(/\r\n|\r|\n/).length,
 		stopped: false,
 		init: false,
@@ -145,7 +145,8 @@ function animateString(str, effect, delay, speed) {
 			}, delay / speed);
 		},
 		frame() {
-			return '\u001B[' + this.lines + 'F\u001B[G\u001B[2K' + effect(this.text, this.f++);
+			this.f++;
+			return '\u001B[' + this.lines + 'F\u001B[G\u001B[2K' + this.text.map(str => effect(str, this.f)).join('\n');
 		},
 		replace(str) {
 			this.text = str;


### PR DESCRIPTION
This PR adds multi-line support, with 2 commits that have different effects:

- cf11942fd2efe1525e304a66b0d0f488aeca6da7 works for rainbow and pulse but glitches for glitch and radar (only for multiline strings where it doesn't work right now anyway)
- 5c65aaf106be6ea70de0b7b4197f98505d121a14 should work for every effect but differently (I actually like how it works not exactly the same for every line but let me know if that's a problem)

Note that for single-line strings (the only strings supported right now by chalk-animation) this PR should have no effect.
