### PR TITLE
fix(replace): allow string to be passed to replace function

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,8 @@ function animateString(str, effect, delay, speed) {
 			return '\u001B[' + this.lines + 'F\u001B[G\u001B[2K' + this.text.map(str => effect(str, this.f)).join('\n');
 		},
 		replace(str) {
-			this.text = str;
+			this.text = (Array.isArray(str) ? str : [str]);
+			return this;
 		},
 		stop() {
 			this.stopped = true;

--- a/test.js
+++ b/test.js
@@ -11,4 +11,12 @@ for (const effect of effects) {
 	test(`doesn't throw (${effect})`, t => {
 		t.notThrows(() => a[effect]('Lorem ipsum dolor sit amet'));
 	});
+
+	test(`can pass string to replace (${effect})`, t => {
+		t.notThrows(() => a[effect]('Lorem ipsum dolor sit amet').replace('a new value').frame());
+	});
+
+	test(`can pass array to replace (${effect})`, t => {
+		t.notThrows(() => a[effect]('Lorem ipsum dolor sit amet').replace(['a new value']).frame());
+	});
 }


### PR DESCRIPTION
Simple check to make sure this.text property is an array after calling replace() function.

Also return 'this' on replace to allow for a more fluent construction.