### PR TITLE
Support for one-liner countdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import gradient from 'gradient-string';
 
-const log = console.log;
+const log = process.stdout.write.bind(process.stdout);;
 let currentAnimation = null;
 
 const consoleFunctions = {
@@ -151,7 +151,7 @@ function animateString(str, effect, delay, speed) {
 		},
 		frame() {
 			this.f++;
-			return '\u001B[' + this.lines + 'F\u001B[G\u001B[2K' + this.text.map(str => effect(str, this.f)).join('\n');
+			return effect(str, this.f) + '\r';
 		},
 		replace(str) {
 			this.text = str.split(/\r\n|\r|\n/);


### PR DESCRIPTION
i made some changes to the index file to support "one-liner" countdown/timer.
Please feel free and make some changes to it so that users who want to use this repo for only terminal countdown can do so easily. Something like 
```
chalkAnimation.rainbow(timeLeft, countDown);
```
will be fun :)

here is a working example of the solution

[![asciicast](https://asciinema.org/a/ImCz2Q1iEspQk4EGF7mtETddD.svg)](https://asciinema.org/a/ImCz2Q1iEspQk4EGF7mtETddD?t=1:26)